### PR TITLE
Switch position of save and cancel/reset buttons

### DIFF
--- a/Resources/ruleset/general/switch-submit-cancel-reset-button.css
+++ b/Resources/ruleset/general/switch-submit-cancel-reset-button.css
@@ -1,0 +1,7 @@
+.modal-footer button[type=submit], .box-footer input[type=submit] {
+    float: right !important
+}
+
+.modal-footer .btn-cancel, .box-footer input[type=reset] {
+    float: left !important
+}


### PR DESCRIPTION
In https://github.com/kevinpapst/kimai2/issues/1515#issuecomment-595128779 @tchristiansen shared his code for switching the "Save" and "Cancel" buttons. 

I've optimized the code for modal forms and "on-page" forms.

